### PR TITLE
Modified nrm2 to prevent overflow.

### DIFF
--- a/nrm2.js
+++ b/nrm2.js
@@ -1,5 +1,17 @@
 'use strict';
 
+var hypot = function hypot (a, b) {
+  if (a === 0 && b === 0) {
+    return 0;
+  }
+  var x = Math.abs(a);
+  var y = Math.abs(b);
+  var t = Math.min(x, y);
+  var u = Math.max(x, y);
+  t = t / u;
+  return u * Math.sqrt(1 + t * t);
+};
+
 module.exports = function nrm2 (x) {
   var i, tmp;
   var dx = x.data;
@@ -8,7 +20,7 @@ module.exports = function nrm2 (x) {
   var sum = 0;
   for (i = x.shape[0] - 1; i >= 0; i--, px += ox) {
     tmp = dx[px];
-    sum += tmp * tmp;
+    sum = hypot(sum, tmp);
   }
-  return Math.sqrt(sum);
+  return sum;
 };

--- a/test/test.js
+++ b/test/test.js
@@ -75,6 +75,8 @@ test('dot (with identical input simplification)', function (t) {
 
 test('nrm2', function (t) {
   t.assert(Math.abs(blas1.nrm2(a) - Math.sqrt(1 * 1 + 2 * 2 + 3 * 3 + 4 * 4)) < 1e-8);
+  t.assert(Math.abs(blas1.nrm2(ndarray(new Float64Array([3.00e-300, 4.00e-300]))) - 5e-300) < 1e-8);
+  t.assert(Math.abs(blas1.nrm2(ndarray(new Float64Array([5.00e+300, 1.20e+301]))) - 1.3e+301) < 1e-8);
   t.end();
 });
 


### PR DESCRIPTION
This method uses the `hypot()` function which inhibits arithmetic underflow and overflow. The function `Math.hypot()` is not used because it's not fully implemented in all browsers yet (there is no support in IE currently).
